### PR TITLE
feat(metrics): Añadir opciones a la función hausdorff_distance

### DIFF
--- a/DL_Track_US/lib_ultrasound_utils/README.md
+++ b/DL_Track_US/lib_ultrasound_utils/README.md
@@ -48,7 +48,7 @@ Su objetivo es comparar el rendimiento de un modelo de segmentación (como el de
 | `jaccard_index()`        | Índice de Jaccard (IoU)               | Mide la intersección sobre la unión; penaliza más los errores que el Dice.          |
 | `sensitivity()`          | Sensibilidad (Recall)                 | Mide la fracción de la máscara real que fue correctamente identificada.             |
 | `precision()`            | Precisión                             | Mide qué tan "limpia" es la predicción, es decir, cuántos píxeles predichos son correctos. |
-| `hausdorff_distance()`   | Distancia de Hausdorff                | Mide el error máximo entre los contornos de las dos máscaras.                       |
+| `hausdorff_distance()`   | Distancia de Hausdorff                | Mide el error máximo entre contornos. Permite elegir la librería (`scipy`/`skimage`) y el método. |
 | `cohen_kappa()`          | Kappa de Cohen                        | Evalúa la concordancia entre las dos máscaras, corrigiendo el acuerdo por azar.     |
 
 **Ejemplo de Uso:**
@@ -64,6 +64,14 @@ mascara_prueba = np.array([[1, 1, 1], [1, 0, 0]], dtype=np.uint8)
 dice = US_metrics.dice_coefficient(mascara_referencia, mascara_prueba)
 iou = US_metrics.jaccard_index(mascara_referencia, mascara_prueba)
 
+# Calcular distancia de Hausdorff con diferentes opciones
+h_scipy = US_metrics.hausdorff_distance(mascara_referencia, mascara_prueba, library='scipy')
+h_skimage = US_metrics.hausdorff_distance(mascara_referencia, mascara_prueba, library='skimage', method='modified')
+
+
 print(f"Coeficiente de Dice: {dice:.4f}")
 print(f"Índice de Jaccard (IoU): {iou:.4f}")
+print(f"Hausdorff (SciPy): {h_scipy:.4f}")
+print(f"Hausdorff (scikit-image, modified): {h_skimage:.4f}")
+
 ```

--- a/DL_Track_US/lib_ultrasound_utils/US_metrics.py
+++ b/DL_Track_US/lib_ultrasound_utils/US_metrics.py
@@ -165,46 +165,49 @@ def precision(reference_mask: np.ndarray, test_mask: np.ndarray, epsilon: float 
     return prec
 
 
-def hausdorff_distance(reference_mask: np.ndarray, test_mask: np.ndarray) -> float:
+def hausdorff_distance(reference_mask: np.ndarray, test_mask: np.ndarray, library: str = 'scipy', method: str = 'standard') -> float:
     """
-    Calcula la Distancia de Hausdorff entre los contornos de dos máscaras. 
-    Aplicarlo en aponeurosis.
+    Calcula la Distancia de Hausdorff entre los contornos de dos máscaras, permitiendo
+    seleccionar la biblioteca de cálculo (`scipy` o `skimage`) y el método.
 
-    Esta métrica mide la máxima distancia entre el contorno de una máscara y el contorno de la otra.
-    Es una medida del "peor error" en la delineación del borde. Un valor más bajo indica
-    una mayor similitud entre los contornos.
-    Evalúa la precisión geométrica, crucial para estructuras finas como las aponeurosis.
-
-    Nota:
-        Si una de las máscaras está completamente vacía, la distancia no se puede calcular
-        y la función devolverá `np.inf`.
+    Esta métrica mide la máxima distancia entre el contorno de una máscara y el de la otra,
+    siendo útil para evaluar la precisión geométrica, especialmente en estructuras finas
+    como las aponeurosis.
 
     Args:
-        reference_mask (np.ndarray): La máscara de referencia (ground truth).
-        test_mask (np.ndarray): La máscara de prueba.
+        reference_mask (np.ndarray): Máscara de referencia (ground truth).
+        test_mask (np.ndarray): Máscara de prueba.
+        library (str, optional): Biblioteca a utilizar. Puede ser 'scipy' o 'skimage'.
+                                 Por defecto es 'scipy'.
+        method (str, optional): Método para `skimage`. Puede ser 'standard' o 'modified'.
+                                Ignorado si `library` es 'scipy'. Por defecto es 'standard'.
 
     Returns:
-        float: El valor de la Distancia de Hausdorff. Puede ser `np.inf` si una máscara está vacía.
+        float: Valor de la Distancia de Hausdorff. Puede ser `np.inf` si una máscara está vacía.
+
+    Raises:
+        ValueError: Si la `library` o el `method` no son válidos.
     """
-    # Obtener las coordenadas de los píxeles del contorno (píxeles > 0)
     coords_reference = np.argwhere(reference_mask)
     coords_test = np.argwhere(test_mask)
 
-    # Si alguna de las máscaras no tiene píxeles positivos, la distancia es infinita
     if len(coords_reference) == 0 or len(coords_test) == 0:
         return np.inf
 
-    # Calcular la distancia de Hausdorff dirigida en ambas direcciones
-    h1 = hausdorff_distance_scipy (coords_reference, coords_test)[0]
-    h2 = hausdorff_distance_scipy (coords_test, coords_reference)[0]
+    if library == 'scipy':
+        h1 = hausdorff_distance_scipy(coords_reference, coords_test)[0]
+        h2 = hausdorff_distance_scipy(coords_test, coords_reference)[0]
+        return max(h1, h2)
 
-    #!!! Alternativa el uso de hausdorff_skimage 
-    # method = {‘standard’, ‘modified’}
-    #h1 = hausdorff_distance_skimage (coords_reference, coords_test,method='standard')
-    #h2 = hausdorff_distance_skimage (coords_test, coords_reference,method='standard')
+    elif library == 'skimage':
+        if method not in ['standard', 'modified']:
+            raise ValueError("El método para 'skimage' debe ser 'standard' o 'modified'.")
 
-    # La distancia de Hausdorff es el máximo de las dos distancias dirigidas
-    return max(h1, h2)
+        dist = hausdorff_distance_skimage(coords_reference, coords_test, method=method)
+        return dist
+
+    else:
+        raise ValueError("La biblioteca debe ser 'scipy' o 'skimage'.")
 
 
 def cohen_kappa(reference_mask: np.ndarray, test_mask: np.ndarray) -> float:


### PR DESCRIPTION
La función hausdorff_distance en US_metrics.py se ha actualizado para permitir cálculos más flexibles.

Cambios clave:
- Los usuarios ahora pueden elegir entre las implementaciones de las bibliotecas «scipy» y «skimage» para el cálculo de la distancia de Hausdorff a través del parámetro «library».
- Cuando se utiliza «skimage», el «método» se puede establecer en «estándar» o «modificado».
- La cadena de documentación de la función y el archivo README.md correspondiente se han actualizado para reflejar estas nuevas opciones y proporcionar ejemplos de uso.

Este cambio preserva la compatibilidad con versiones anteriores al establecer como valor predeterminado la implementación original «scipy».